### PR TITLE
added all new domains

### DIFF
--- a/guides/domain.mdx
+++ b/guides/domain.mdx
@@ -7,7 +7,7 @@ icon: globe
 
 ## What domains are Available Right now?
 
-- These are the domains that are available and ready to use: [haunt.gg](https://haunt.gg/), [exitscam.xyz](https://exitscam.xyz/), [fentanyl.ing](https://fentanyl.ing), [rich.bz](https://rich.bz/), [haunt.bio](https://haunt.bio/)
+- These are the domains that are available and ready to use: [haunt.gg](https://haunt.gg/), [exitscam.xyz](https://exitscam.xyz/), [fentanyl.ing](https://fentanyl.ing), [rich.bz](https://rich.bz/), [haunt.bio](https://haunt.bio/), [best-bio.site](https://best-bio.site)
 
 ## How can I use those domains?
 

--- a/guides/imagehost.mdx
+++ b/guides/imagehost.mdx
@@ -44,6 +44,7 @@ Never share your API key with anyone — it could allow others to upload images 
 
 <Accordion title="Supported Domains">
 - i.haunt.gg  
+- 361.reaszy.com
 - zleni.xyz (Subdomain)  
 - bxrnt.live (Subdomain)  
 - haunt.host (Subdomain)

--- a/guides/imagehost.mdx
+++ b/guides/imagehost.mdx
@@ -53,6 +53,9 @@ Never share your API key with anyone — it could allow others to upload images 
 - mrak.me (Subdomain)
 - nitro.rest (Subdomain)
 - syra.systems (Subdomain)
+- storagevault.cloud (Subdomain)
+- slime.rest (Subdomain)
+- i-love-your.mom (Subdomain)
 </Accordion>
 
 <Tip>

--- a/guides/imagehost.mdx
+++ b/guides/imagehost.mdx
@@ -44,6 +44,11 @@ Never share your API key with anyone — it could allow others to upload images 
 
 <Accordion title="Supported Domains">
 - i.haunt.gg  
+- i.rich.bz
+- i.exitscam.xyz
+- i.fentanyl.ing
+- i.haunt.bio
+- i.best-bio.site
 - 361.reaszy.com
 - zleni.xyz (Subdomain)  
 - bxrnt.live (Subdomain)  

--- a/guides/imagehost.mdx
+++ b/guides/imagehost.mdx
@@ -47,6 +47,12 @@ Never share your API key with anyone — it could allow others to upload images 
 - zleni.xyz (Subdomain)  
 - bxrnt.live (Subdomain)  
 - haunt.host (Subdomain)
+- carti.pics (Subdomain)
+- haunt.edu.pl (Subdomain)
+- is-handso.me (Subdomain)
+- mrak.me (Subdomain)
+- nitro.rest (Subdomain)
+- syra.systems (Subdomain)
 </Accordion>
 
 <Tip>


### PR DESCRIPTION
added all (sub)domains to imagehost guide:

- i.rich.bz
- i.exitscam.xyz
- i.fentanyl.ing
- i.haunt.bio
- i.best-bio.site
- 361.reaszy.com
- carti.pics (Subdomain)
- haunt.edu.pl (Subdomain)
- is-handso.me (Subdomain)
- mrak.me (Subdomain)
- nitro.rest (Subdomain)
- syra.systems (Subdomain)
- storagevault.cloud (Subdomain)
- slime.rest (Subdomain)
- i-love-your.mom (Subdomain)

added all domains to domain guide:

- best-bio.site