### PR TITLE
fix(css): preserve PNG transparency in inactive tab icons

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -74,3 +74,31 @@ html::-webkit-scrollbar, body::-webkit-scrollbar {
     max-width: 72rem !important;
   }
 }
+
+[role="tab"]:not([aria-selected="true"]) img {
+  filter: none !important;
+  opacity: 0.7 !important;
+  background: transparent !important;
+  mix-blend-mode: normal !important;
+}
+
+[role="tab"] img {
+  background: transparent !important;
+}
+
+.tab:not(.active) img {
+  filter: none !important;
+  opacity: 0.7 !important;
+  background: transparent !important;
+}
+
+.tab-button:not(.tab-button-active) img {
+  filter: none !important;
+  opacity: 0.7 !important;
+  background: transparent !important;
+}
+
+img[src*=".png"] {
+  background: transparent !important;
+  mix-blend-mode: normal !important;
+}


### PR DESCRIPTION
Fixed the issue where the ShareX PNG icon lost transparency when the tab was not selected:

Before → https://a.bxrnt.live/Mhml0fK1.png
After → https://a.bxrnt.live/GsyK075v.png

